### PR TITLE
fix git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is an open UI for Hydra, a protocol on Solana for facilitating collective a
 ## Getting Started
 
 ```bash
-git clone git@github.com:metaplex-foundation/hydra-ui.git
+git clone https://github.com/metaplex-foundation/hydra-ui.git
 cd hydra-ui
 yarn install
 yarn dev

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is an open UI for Hydra, a protocol on Solana for facilitating collective a
 ## Getting Started
 
 ```bash
-git clone https://github.com/cardinal-labs/hydra-ui.git
+git clone git@github.com:metaplex-foundation/hydra-ui.git
 cd hydra-ui
 yarn install
 yarn dev


### PR DESCRIPTION
was pointing to the original cardinal url still